### PR TITLE
Use ::class notation for referencing class names

### DIFF
--- a/wp-content/themes/sample-theme/functions.php
+++ b/wp-content/themes/sample-theme/functions.php
@@ -3,7 +3,7 @@
 namespace XWP\Sample_Theme;
 
 // Include the local autoloader only if the global one isn't available.
-if ( ! class_exists( 'XWP\Sample_Theme\Theme' ) && file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+if ( ! class_exists( Theme::class ) && file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
     require_once __DIR__ . '/vendor/autoload.php';
 }
 


### PR DESCRIPTION
Just that.

```
$ php -r 'namespace XWP\Sample_Theme; echo Theme::class;'
XWP\Sample_Theme\Theme
```
